### PR TITLE
feat: replace shell-based JSON building with jq

### DIFF
--- a/src/scripts/trigger.sh
+++ b/src/scripts/trigger.sh
@@ -28,13 +28,9 @@ if [ -z "$PARAM_TOKEN" ]; then
 fi
 
 if [ -n "$PARAM_PARAMETERS" ]; then
-    PARAMETERS=$(echo "$PARAM_PARAMETERS" | awk -F, '{
-        for (i = 1; i <= NF; i++) {
-            split($i, pair, "=");
-            if (i > 1) printf ",";
-            printf "\""pair[1]"\":\""pair[2]"\"";
-        }
-    }' | sed 's/^/{/; s/$/}/')
+    PARAMETERS=$(printf '%s\n' "$PARAM_PARAMETERS" | jq -Rn '
+      ( input | split(",") | map( split("=") | { (.[0]): .[1] } ) | add )
+    ')
 else
     PARAMETERS="{}"
 fi


### PR DESCRIPTION
The orb constructs JSON from a comma-separated key=value list using a combination of `awk` and `sed`. While functional for simple inputs, this approach relies on shell text parsing hacks that are inherently brittle:

* Fails if keys or values contain special characters such as quotes, commas, backslashes, or whitespace.
* Assumes every field contains =, with no validation.
* Requires multiple external tools (`awk` + `sed`) and ad-hoc escaping logic.

This change replaces the manual parsing with `jq -Rn`, which:

* Properly handles quoting and escaping for all valid JSON strings.
* Supports arbitrary characters in keys and values without breaking JSON validity.
* Produces predictable, standards-compliant output across platforms.
* Simplifies the implementation by removing awk/sed in favour of jq, which is required anyway.

> [!NOTE]
> `printf "%s\n"` (POSIX compliant) guarantees jq gets exactly the intended input